### PR TITLE
avoid creating config folder for dev-env build

### DIFF
--- a/jobs/fetch/run_slave.sh
+++ b/jobs/fetch/run_slave.sh
@@ -49,9 +49,7 @@ function run_dev_env() {
 
   cd $WORKSPACE/src/tungstenfabric/tf-dev-env
   if ((0 != build_dev_env)); then
-    local y=./config/etc/yum.repos.d
-    mkdir -p $y
-    cp ${my_dir}/../common/pnexus.repo $y/
+    cp ${my_dir}/../common/pnexus.repo container/
   fi
 
   ./run.sh $stage

--- a/jobs/test/unit/run.sh
+++ b/jobs/test/unit/run.sh
@@ -43,9 +43,7 @@ timedatectl
 
 cd src/tungstenfabric/tf-dev-env
 if [[ -z "$@" && "\${ENVIRONMENT_OS,,}" == centos7 ]]; then
-  local y=./config/etc/yum.repos.d
-  mkdir -p \${y}
-  cp ${WORKSPACE}/src/progmaticlab/tf-jenkins/jobs/common/pnexus.repo \${y}/
+  cp ${WORKSPACE}/src/progmaticlab/tf-jenkins/jobs/common/pnexus.repo container/
 fi
 ./run.sh $@
 EOF


### PR DESCRIPTION
creating the folder incurs forwarding the folder into the
container. this prevents container from starting at another host
bacause the folder is not there in general case.
let's copy repos directly to container folder not depend on
the implicit build logic.